### PR TITLE
Core migration

### DIFF
--- a/src/Hateline.csproj
+++ b/src/Hateline.csproj
@@ -8,12 +8,23 @@
         <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\Celeste.exe')">..\..</CelestePrefix>
         <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\..\Celeste.exe')">..\..\..</CelestePrefix>
         <CelestePrefix Condition="'$(CelestePrefix)' == ''">lib-stripped</CelestePrefix>
+
+        <!-- Use the legacy reference dir for Core installs -->
+        <CelesteIsCore>false</CelesteIsCore>
+        <CelesteIsCore Condition="Exists('$(CelestePrefix)\Celeste.dll')">true</CelesteIsCore>
+        <CelestePrefix Condition="$(CelesteIsCore)">$(CelestePrefix)\legacyRef</CelestePrefix>
+        
         <CelesteType Condition="'$(CelesteType)' == '' And Exists('$(CelestePrefix)\BuildIsXNA.txt')">XNA</CelesteType>
         <CelesteType Condition="'$(CelesteType)' == ''">FNA</CelesteType>
         <XNAPath Condition="'$(XNAPath)' == ''">$(WINDIR)\Microsoft.NET\assembly\GAC_32\{0}\v4.0_4.0.0.0__842cf8be1de50553\{0}.dll</XNAPath>
         <BaseOutputPath>bin\</BaseOutputPath>
         <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
     </PropertyGroup>
+    
+    <Target Name="CheckCoreInstall" BeforeTargets="PrepareForBuild" Condition="$(CelesteIsCore)">
+        <Error Condition="!Exists('$(CelestePrefix)')" Text="Detected a .NET Core Everest install without the required legacyRef install needed to build .NET Framework mods - see the Everest wiki (https://github.com/EverestAPI/Resources/wiki/Code-Mod-Core-Migration-Guide) for info on how to set it up" />
+        <Message Text="Building against .NET Core Everest legacyRef install" Importance="high" />
+    </Target>
 
     <!--Disable "Copy Local" for all references-->
     <ItemDefinitionGroup>
@@ -27,10 +38,6 @@
       <EmbeddedResource Remove="Graphics\**" />
       <None Remove="Dialog\**" />
       <None Remove="Graphics\**" />
-    </ItemGroup>
-    <ItemGroup>
-      <None Remove="everest.yaml" />
-      <None Remove="README.md" />
     </ItemGroup>
 
     <ItemGroup>
@@ -51,16 +58,16 @@
           <HintPath>..\..\CelesteNet.Client\CelesteNet.Shared.dll</HintPath>
         </Reference>
         <Reference Include="Mono.Cecil">
-          <HintPath>..\..\Mono.Cecil.dll</HintPath>
+          <HintPath>$(CelestePrefix)\Mono.Cecil.dll</HintPath>
         </Reference>
         <Reference Include="MonoMod.RuntimeDetour">
-          <HintPath>..\..\MonoMod.RuntimeDetour.dll</HintPath>
+          <HintPath>$(CelestePrefix)\MonoMod.RuntimeDetour.dll</HintPath>
         </Reference>
         <Reference Include="MonoMod.Utils">
-          <HintPath>..\..\MonoMod.Utils.dll</HintPath>
+          <HintPath>$(CelestePrefix)\MonoMod.Utils.dll</HintPath>
         </Reference>
         <Reference Include="YamlDotNet">
-          <HintPath>..\..\..\YamlDotNet.dll</HintPath>
+          <HintPath>$(CelestePrefix)\YamlDotNet.dll</HintPath>
         </Reference>
     </ItemGroup>
 

--- a/src/Hateline.csproj
+++ b/src/Hateline.csproj
@@ -1,29 +1,23 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net452</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <AssemblyName>Hateline</AssemblyName>
         <RootNamespace>Celeste.Mod.Hateline</RootNamespace>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>11</LangVersion>
         <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\Celeste.exe')">..\..</CelestePrefix>
         <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\..\Celeste.exe')">..\..\..</CelestePrefix>
+        <CelestePrefix Condition="'$(CelestePrefix)' == '' And Exists('..\..\..\Celeste.dll')">..\..\..</CelestePrefix>
         <CelestePrefix Condition="'$(CelestePrefix)' == ''">lib-stripped</CelestePrefix>
 
-        <!-- Use the legacy reference dir for Core installs -->
-        <CelesteIsCore>false</CelesteIsCore>
-        <CelesteIsCore Condition="Exists('$(CelestePrefix)\Celeste.dll')">true</CelesteIsCore>
-        <CelestePrefix Condition="$(CelesteIsCore)">$(CelestePrefix)\legacyRef</CelestePrefix>
-        
-        <CelesteType Condition="'$(CelesteType)' == '' And Exists('$(CelestePrefix)\BuildIsXNA.txt')">XNA</CelesteType>
-        <CelesteType Condition="'$(CelesteType)' == ''">FNA</CelesteType>
-        <XNAPath Condition="'$(XNAPath)' == ''">$(WINDIR)\Microsoft.NET\assembly\GAC_32\{0}\v4.0_4.0.0.0__842cf8be1de50553\{0}.dll</XNAPath>
         <BaseOutputPath>bin\</BaseOutputPath>
         <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
     </PropertyGroup>
-    
-    <Target Name="CheckCoreInstall" BeforeTargets="PrepareForBuild" Condition="$(CelesteIsCore)">
-        <Error Condition="!Exists('$(CelestePrefix)')" Text="Detected a .NET Core Everest install without the required legacyRef install needed to build .NET Framework mods - see the Everest wiki (https://github.com/EverestAPI/Resources/wiki/Code-Mod-Core-Migration-Guide) for info on how to set it up" />
-        <Message Text="Building against .NET Core Everest legacyRef install" Importance="high" />
+
+    <Target Name="EnsureCelesteExists" BeforeTargets="PreBuildEvent">
+        <Error
+          Condition="!Exists('$(CelestePrefix)\Celeste.dll')"
+          Text="Cannot find Celeste. Make sure CelesteNet is cloned in your Celeste/Mods folder. Alternatively, copy Celeste.dll, FNA.dll and MMHOOK_Celeste.dll to a folder called 'lib-stripped' in the repository root." />
     </Target>
 
     <!--Disable "Copy Local" for all references-->
@@ -45,7 +39,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Include="$(CelestePrefix)\Celeste.exe">
+        <Reference Include="$(CelestePrefix)\Celeste.dll">
             <Private>false</Private>
         </Reference>
         <Reference Include="$(CelestePrefix)\MMHOOK_Celeste.dll">
@@ -69,31 +63,10 @@
         <Reference Include="YamlDotNet">
           <HintPath>$(CelestePrefix)\YamlDotNet.dll</HintPath>
         </Reference>
+        <Reference Include="$(CelestePrefix)\FNA.dll">
+            <Private>false</Private>
+        </Reference>
     </ItemGroup>
-
-    <Choose>
-        <When Condition="'$(CelesteType)' == 'FNA'">
-            <ItemGroup>
-                <Reference Include="$(CelestePrefix)\FNA.dll">
-                    <Private>false</Private>
-                </Reference>
-            </ItemGroup>
-        </When>
-
-        <When Condition="'$(CelesteType)' == 'XNA'">
-            <ItemGroup>
-                <Reference Include="$([System.String]::Format('$(XNAPath)', 'Microsoft.Xna.Framework'))">
-                    <Private>false</Private>
-                </Reference>
-                <Reference Include="$([System.String]::Format('$(XNAPath)', 'Microsoft.Xna.Framework.Game'))">
-                    <Private>false</Private>
-                </Reference>
-                <Reference Include="$([System.String]::Format('$(XNAPath)', 'Microsoft.Xna.Framework.Graphics'))">
-                    <Private>false</Private>
-                </Reference>
-            </ItemGroup>
-        </When>
-    </Choose>
 
     <Target Name="CopyFiles" AfterTargets="Build">
         <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="bin" />


### PR DESCRIPTION
First commit for building with legacyRef, but can't seem to build against CelesteNet v2.3.0 which is now a net7.0 build.

Second commit makes this a Core mod as well, build with net7.0 instead of net452. No more legacyRef necessary, builds with CelesteNet v2.3.0

I only set Language to 11 rather than latest because I have net8.0 installed and it kept letting me build net7.0 with C# 12 syntax even though the net7.0 SDK doesn't support C# 12... idk how else to avoid that and I'm lazy. Can always bump the LangVersion if you ever bump this to net8.0 etc.

Also dropped the Remove="everest.yaml" and Remove="README.md" because why not make it possible to see and edit those in VS :3
(Edit: actually nvm, those files aren't even in src/ folder anyways lol)